### PR TITLE
Align .text .rodata and thread stacks to use PMP NAPOT addressing

### DIFF
--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -2,6 +2,7 @@
  * Copyright (c) 2016 Jean-Paul Etienne <fractalclone@gmail.com>
  * Copyright (c) 2018 Foundries.io Ltd
  * Copyright (c) 2020 BayLibre, SAS
+ * Copyright (c) 2020 RISE Research Institutes of Sweden
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/arch/riscv/core/pmp/core_pmp.c
+++ b/arch/riscv/core/pmp/core_pmp.c
@@ -10,6 +10,58 @@
 #include <arch/riscv/csr.h>
 #include <stdio.h>
 
+/* Each 32-bit pmpcfg# register contains four 8-bit configuration sections.
+ * These section numbers contain flags which apply to region defined by the
+ * corresponding pmpaddr# register.
+ *
+ *    3                   2                   1
+ *  1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |    pmp3cfg    |    pmp2cfg    |    pmp1cfg    |    pmp0cfg    | pmpcfg0
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |    pmp7cfg    |    pmp6cfg    |    pmp5cfg    |    pmp4cfg    | pmpcfg2
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ *     7       6       5       4       3       2       1       0
+ * +-------+-------+-------+-------+-------+-------+-------+-------+
+ * |   L   |       0       |       A       |   X   |   W   |   R   | pmp#cfg
+ * +-------+-------+-------+-------+-------+-------+-------+-------+
+ *
+ *	  L: locks configuration until system reset (including M-mode)
+ *	  0: hardwired to zero
+ *	  A: 0 = OFF (null region / disabled)
+ *	     1 = TOR (top of range)
+ * 	     2 = NA4 (naturally aligned four-byte region)
+ *	     3 = NAPOT (naturally aligned power-of-two region, > 7 bytes)
+ *	  X: execute
+ *	  W: write
+ *	  R: read
+ *
+ * TOR: Each 32-bit pmpaddr# register defines the upper bound of the PMP region
+ * right-shifted by two bits. The lower bound of the region is the previous
+ * pmpaddr# register. In the case of pmpaddr0, the lower bound is address 0x0.
+ *
+ *    3                   2                   1
+ *  1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                        address[33:2]                          | pmpaddr#
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ * NAPOT: Each 32-bit pmpaddr# register defines the start address and the size
+ * of the PMP region. The number of concurrent 1s begging at the LSB indicates
+ * the size of the region as a power of two (e.g. 0x...0 = 8-byte, 0x...1 =
+ * 16-byte, 0x...11 = 32-byte, etc.).
+ *
+ *    3                   2                   1
+ *  1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                        address[33:2]                |0|1|1|1|1| pmpaddr#
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ * NA4: This is essentially an edge case of NAPOT where the entire pmpaddr#
+ * register defines a 4-byte wide region.
+ */
+
 #define PMP_SHIFT_ADDR	2
 #define PMPCFG_COUNT	4
 #define PMP_SLOT_NUMBER	CONFIG_PMP_SLOT
@@ -223,8 +275,33 @@ void pmp_print(unsigned int index)
 }
 
 #if defined(CONFIG_USERSPACE)
+#include <linker/linker-defs.h>
 void init_user_accesses(struct k_thread *thread)
 {
+	/* Userspace threads are configured by default to isolate .text,
+	 * .rodata and their own stack. A single 4-byte region allows read-only
+	 * access to the global is_user_mode flag. The remaining PMP registers
+	 * are reserved for user-defined memory partitions.
+	 *
+	 * If stack guards are enabled, pmpaddr0 will be the global interrupt
+	 * stack guard, and the registers below will be incremented by one.
+	 *
+	 *  +=========+ <--  0x0
+	 *  +---------+ <--  pmpaddr0 [NAPOT, RX]
+	 *  |  .text  |
+	 *  +---------+
+	 *  +---------+ <--  pmpaddr1 [NAPOT, RO]
+	 *  | .rodata |
+	 *  +---------+
+	 *  +---------+
+	 *  |   mode  | <--  pmpaddr2 [NA4, RO]
+	 *  +---------+
+	 *  +---------+ <--  pmpaddr3 [NAPOT, RW]
+	 *  |  stack  |
+	 *  +---------+
+	 *  +=========+
+	 */
+
 	unsigned char index;
 	unsigned char *uchar_pmpcfg;
 
@@ -235,23 +312,27 @@ void init_user_accesses(struct k_thread *thread)
 	index++;
 #endif /* CONFIG_PMP_STACK_GUARD */
 
-	/* MCU state */
+	/* Program data */
+	thread->arch.u_pmpaddr[index] =
+		TO_PMP_ADDR((ulong_t)_image_text_start) |
+		TO_NAPOT_RANGE(POW2_CEIL((ulong_t)_image_text_size));
+	uchar_pmpcfg[index++] = PMP_NAPOT | PMP_R | PMP_X;
+
+	/* Read-only data */
+	thread->arch.u_pmpaddr[index] =
+		TO_PMP_ADDR((ulong_t)_image_rodata_start) |
+		TO_NAPOT_RANGE(POW2_CEIL((ulong_t)_image_rodata_size));
+	uchar_pmpcfg[index++] = PMP_NAPOT | PMP_R;
+
+	/* Privilege level */
 	thread->arch.u_pmpaddr[index] = TO_PMP_ADDR((ulong_t) &is_user_mode);
 	uchar_pmpcfg[index++] = PMP_NA4 | PMP_R;
 
-	/* Program and RO data */
-	thread->arch.u_pmpaddr[index] = TO_PMP_ADDR(0x20000000);
-	uchar_pmpcfg[index++] = PMP_NA4 | PMP_R | PMP_X;
-	thread->arch.u_pmpaddr[index] = TO_PMP_ADDR(0x80000000);
-	uchar_pmpcfg[index++] = PMP_TOR | PMP_R | PMP_X;
-
-	/* RAM */
-	thread->arch.u_pmpaddr[index] = TO_PMP_ADDR(thread->stack_info.start +
-		PMP_GUARD_ALIGN_AND_SIZE);
-	uchar_pmpcfg[index++] = PMP_NA4 | PMP_R | PMP_W;
-	thread->arch.u_pmpaddr[index] = TO_PMP_ADDR(thread->stack_info.start +
-		thread->stack_info.size);
-	uchar_pmpcfg[index++] = PMP_TOR | PMP_R | PMP_W;
+	/* Thread stack */
+	thread->arch.u_pmpaddr[index] =
+		TO_PMP_ADDR((ulong_t)thread->stack_info.start) |
+		TO_NAPOT_RANGE((ulong_t)thread->stack_info.size);
+	uchar_pmpcfg[index++] = PMP_NAPOT | PMP_R | PMP_W;
 }
 
 void configure_user_allowed_stack(struct k_thread *thread)

--- a/arch/riscv/core/userspace.S
+++ b/arch/riscv/core/userspace.S
@@ -2,6 +2,7 @@
  * Userspace and service handler hooks
  *
  * Copyright (c) 2020 BayLibre, SAS
+ * Copyright (c) 2020 RISE Research Institutes of Sweden
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/arch/riscv/arch.h
+++ b/include/arch/riscv/arch.h
@@ -206,6 +206,31 @@ static inline uint32_t arch_k_cycle_get_32(void)
 
 #ifdef CONFIG_USERSPACE
 #include <arch/riscv/error.h>
+
+#define POW2_CEIL(x) ((1 << (31 - __builtin_clz(x))) < x ?  \
+		1 << (31 - __builtin_clz(x) + 1) : \
+		1 << (31 - __builtin_clz(x)))
+
+#ifndef CONFIG_PMP_STACK_GUARD
+/*
+ * The following macros generate naturally-aligned power-of-two privilege stacks
+ * for userspace threads. See sys/thread_stack.h for more information.
+ */
+#define ARCH_THREAD_STACK_LEN(size) (POW2_CEIL(size))
+#define ARCH_THREAD_STACK_MEMBER(sym, size) \
+	struct z_thread_stack_element __aligned(POW2_CEIL(size)) \
+		sym[POW2_CEIL(size)]
+#define ARCH_THREAD_STACK_SIZEOF(sym) (sizeof(sym))
+#define ARCH_THREAD_STACK_BUFFER(sym) ((char *)(sym))
+#define ARCH_THREAD_STACK_RESERVED 0
+#define ARCH_THREAD_STACK_ARRAY_DEFINE(sym, nmemb, size) \
+	struct z_thread_stack_element __noinit \
+		__aligned(POW2_CEIL(size)) \
+		sym[nmemb][ARCH_THREAD_STACK_LEN(size)]
+#define ARCH_THREAD_STACK_DEFINE(sym, size) \
+	struct z_thread_stack_element __noinit \
+		__aligned(POW2_CEIL(size)) sym[POW2_CEIL(size)]
+#endif /* CONFIG_PMP_STACK_GUARD */
 #endif /* CONFIG_USERSPACE */
 
 #ifdef __cplusplus

--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -31,6 +31,11 @@
 #define _EXCEPTION_SECTION_NAME     exceptions
 #define _RESET_SECTION_NAME         reset
 
+#define _region_min_align 4
+#define MPU_ALIGN(region_size) \
+	. = ALIGN(_region_min_align); \
+	. = ALIGN(1 << LOG2CEIL(region_size))
+
 MEMORY
 {
 #ifdef CONFIG_XIP
@@ -100,6 +105,10 @@ SECTIONS
 		KEEP(*(.openocd_debug))
 		KEEP(*(".openocd_debug.*"))
 
+#ifdef CONFIG_USERSPACE
+		MPU_ALIGN(_image_text_size);
+#endif
+
 		_image_text_start = .;
 
 		*(.text)
@@ -110,13 +119,19 @@ SECTIONS
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
     _image_text_end = .;
-
-	_image_rodata_start = .;
-#include <linker/common-rom.ld>
+    _image_text_size = _image_text_end - _image_text_start;
 
     SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
 	{
-		 . = ALIGN(4);
+#ifdef CONFIG_USERSPACE
+		MPU_ALIGN(_image_text_size);
+		MPU_ALIGN(_image_rodata_size);
+#else
+		. = ALIGN(4);
+#endif
+
+		_image_rodata_start = .;
+
 		 *(.srodata)
 		 *(".srodata.*")
 		 *(.rodata)
@@ -132,9 +147,11 @@ SECTIONS
 	. = ALIGN(4);
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
+#include <linker/common-rom.ld>
 #include <linker/cplusplus-rom.ld>
 	_image_rodata_end = .;
-    _image_rom_end = .;
+	_image_rodata_size = _image_rodata_end - _image_rodata_start;
+	_image_rom_end = .;
 	_image_rom_size = _image_rom_end - _image_rom_start;
     GROUP_END(ROMABLE_REGION)
 

--- a/include/arch/riscv/syscall.h
+++ b/include/arch/riscv/syscall.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 BayLibre, SAS
+ * Copyright (c) 2020 RISE Research Institutes of Sweden
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/arch/riscv/thread.h
+++ b/include/arch/riscv/thread.h
@@ -53,19 +53,21 @@
 #ifdef CONFIG_USERSPACE
 #ifdef CONFIG_PMP_STACK_GUARD
 /*
- * 1 for interrupt stack guard: None
- * 1 for core state: R
- * 2 for program and read only data: RX
- * 2 for user thread stack: RW
+ * pmpaddr0 global interrupt stack guard [NA4]
+ * pmpaddr1 .text [NAPOT, RX]
+ * pmpaddr2 .rodata [NAPOT, RO]
+ * pmpaddr3 is_user_mode [NA4, RO]
+ * pmpaddr4 stack [NAPOT, RW]
  */
-#define PMP_REGION_NUM_FOR_U_THREAD	6
+#define PMP_REGION_NUM_FOR_U_THREAD 	5
 #else
 /*
- * 1 for core state: R
- * 2 for program and read only data: RX
- * 2 for user thread stack: RW
+ * pmpaddr0 .text [NAPOT, RX]
+ * pmpaddr1 .rodata [NAPOT, RO]
+ * pmpaddr2 is_user_mode [NA4, RO]
+ * pmpaddr3 stack [NAPOT, RW]
  */
-#define PMP_REGION_NUM_FOR_U_THREAD	5
+#define PMP_REGION_NUM_FOR_U_THREAD	4
 #endif
 #define PMP_MAX_DYNAMIC_REGION	(CONFIG_PMP_SLOT - PMP_REGION_NUM_FOR_U_THREAD)
 #endif

--- a/samples/userspace/syscall_perf/src/main.c
+++ b/samples/userspace/syscall_perf/src/main.c
@@ -16,11 +16,11 @@ void main(void)
 
 	k_thread_create(&supervisor_thread, supervisor_stack, THREAD_STACKSIZE,
 			supervisor_thread_function, NULL, NULL, NULL,
-			-1, K_INHERIT_PERMS, 0);
+			-1, K_INHERIT_PERMS, K_NO_WAIT);
 
-	k_sleep(1000);
+	k_sleep(K_MSEC(1000));
 
 	k_thread_create(&user_thread, user_stack, THREAD_STACKSIZE,
 			user_thread_function, NULL, NULL, NULL,
-			-1, K_USER | K_INHERIT_PERMS, 0);
+			-1, K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 }

--- a/samples/userspace/syscall_perf/src/test_supervisor.c
+++ b/samples/userspace/syscall_perf/src/test_supervisor.c
@@ -21,7 +21,7 @@ void supervisor_thread_function(void *p1, void *p2, void *p3)
 	printf("Supervisor thread started\n");
 
 	while (1) {
-		k_sleep(2000);
+		k_sleep(K_MSEC(2000));
 
 		inst_before = csr_read(0xB02);
 		cycle_before = csr_read(0xB00);

--- a/samples/userspace/syscall_perf/src/test_user.c
+++ b/samples/userspace/syscall_perf/src/test_user.c
@@ -21,7 +21,7 @@ void user_thread_function(void *p1, void *p2, void *p3)
 	printf("User thread started\n");
 
 	while (1) {
-		k_sleep(2000);
+		k_sleep(K_MSEC(2000));
 
 		inst_before = csr_read(0xC02);
 		cycle_before = csr_read(0xC00);


### PR DESCRIPTION
The text and read-only data sections can be given separate permissions
with a single PMP register each using NAPOT addressing instead of TOR.
Thread stacks are also aligned by size, which saves a PMP register. This
reduces the user thread system call latency from ~18000 cycles to ~5280
cycles.

Signed-off-by: Samuel Lindemer <samuel.lindemer@gmail.com>